### PR TITLE
Improve managing client connections, replaced Pulsar consumer with reader

### DIFF
--- a/adapters/backend/v1/adapter.go
+++ b/adapters/backend/v1/adapter.go
@@ -21,15 +21,15 @@ type Adapter struct {
 	connMapMutex  sync.RWMutex
 	connectionMap map[string]domain.ClientIdentifier // <cluster, account> -> <connection string>
 	producer      messaging.MessageProducer
-	consumer      messaging.MessageConsumer
+	reader        messaging.MessageReader
 	once          sync.Once
 	mainContext   context.Context
 }
 
-func NewBackendAdapter(mainContext context.Context, messageProducer messaging.MessageProducer, messageConsumer messaging.MessageConsumer) *Adapter {
+func NewBackendAdapter(mainContext context.Context, messageProducer messaging.MessageProducer, messageReader messaging.MessageReader) *Adapter {
 	adapter := &Adapter{
 		producer:      messageProducer,
-		consumer:      messageConsumer,
+		reader:        messageReader,
 		mainContext:   mainContext,
 		connectionMap: make(map[string]domain.ClientIdentifier),
 	}
@@ -93,7 +93,7 @@ func (b *Adapter) RegisterCallbacks(ctx context.Context, callbacks domain.Callba
 
 func (b *Adapter) Start(ctx context.Context) error {
 	b.once.Do(func() {
-		b.consumer.Start(b.mainContext, b)
+		b.reader.Start(b.mainContext, b)
 	})
 
 	b.connMapMutex.Lock()

--- a/adapters/backend/v1/adapter.go
+++ b/adapters/backend/v1/adapter.go
@@ -43,7 +43,7 @@ func (b *Adapter) getClient(ctx context.Context) (adapters.Client, error) {
 	if client, ok := b.clientsMap.Load(id.String()); ok {
 		return client, nil
 	}
-	return nil, fmt.Errorf("unknown resource %s", id.String())
+	return nil, fmt.Errorf("client was missing from map %s (probably disconnected client)", id.String())
 }
 
 func (b *Adapter) Callbacks(ctx context.Context) (domain.Callbacks, error) {
@@ -51,7 +51,7 @@ func (b *Adapter) Callbacks(ctx context.Context) (domain.Callbacks, error) {
 	if callbacks, ok := b.callbacksMap.Load(id.String()); ok {
 		return callbacks, nil
 	}
-	return domain.Callbacks{}, fmt.Errorf("unknown resource %s", id.String())
+	return domain.Callbacks{}, fmt.Errorf("callbacks for client %s were missing (probably disconnected client)", id.String())
 }
 
 func (b *Adapter) DeleteObject(ctx context.Context, id domain.KindName) error {
@@ -139,7 +139,7 @@ func (b *Adapter) Stop(ctx context.Context) error {
 	b.connMapMutex.Lock()
 	defer b.connMapMutex.Unlock()
 
-	logger.L().Info("starting synchronizer backend adapter",
+	logger.L().Info("stopping synchronizer backend adapter",
 		helpers.String("connectionString", toDelete.ConnectionString()),
 	)
 	// an existing different connection connection was found

--- a/adapters/backend/v1/client.go
+++ b/adapters/backend/v1/client.go
@@ -38,7 +38,8 @@ func (c *Client) Stop(ctx context.Context) error {
 }
 
 func (c *Client) IsRelated(ctx context.Context, id domain.ClientIdentifier) bool {
-	return true
+	identifierFromContext := utils.ClientIdentifierFromContext(ctx)
+	return identifierFromContext.Cluster == id.Cluster && identifierFromContext.Account == id.Account
 }
 
 func (c *Client) sendServerConnectedMessage(ctx context.Context) error {

--- a/adapters/backend/v1/pulsar.go
+++ b/adapters/backend/v1/pulsar.go
@@ -80,7 +80,7 @@ func (c *PulsarMessageReader) Start(mainCtx context.Context, adapter adapters.Ad
 
 func (c *PulsarMessageReader) readerLoop(ctx context.Context) {
 	for {
-		msg, err := c.reader.Next(context.Background())
+		msg, err := c.reader.Next(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/adapters/incluster/v1/adapter.go
+++ b/adapters/incluster/v1/adapter.go
@@ -120,7 +120,7 @@ func (a *Adapter) Start(ctx context.Context) error {
 }
 
 func (a *Adapter) Stop(ctx context.Context) error {
-	return a.Stop(ctx)
+	return nil
 }
 
 func (a *Adapter) IsRelated(ctx context.Context, id domain.ClientIdentifier) bool {

--- a/cmd/server/authentication/authentication.go
+++ b/cmd/server/authentication/authentication.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/synchronizer/config"
@@ -93,13 +94,21 @@ func AuthenticationServerMiddleware(cfg *config.AuthenticationServerConfig, next
 			}
 		}
 
-		logger.L().Debug("connection authenticated", helpers.String("account", account), helpers.String("cluster", cluster))
+		connId := uuid.New().String()
+
+		logger.L().Debug("connection authenticated",
+			helpers.String("account", account),
+			helpers.String("cluster", cluster),
+			helpers.String("connId", connId),
+		)
 
 		// create new context with client identifier
 		ctx := context.WithValue(r.Context(), domain.ContextKeyClientIdentifier, domain.ClientIdentifier{
-			Account: account,
-			Cluster: cluster,
+			Account:      account,
+			Cluster:      cluster,
+			ConnectionId: connId,
 		})
+
 		// create new request using the new context
 		authenticatedRequest := r.WithContext(ctx)
 		next.ServeHTTP(w, authenticatedRequest)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -59,12 +59,12 @@ func main() {
 			logger.L().Fatal("failed to create pulsar producer", helpers.Error(err), helpers.String("config", fmt.Sprintf("%+v", cfg.Backend.PulsarConfig)))
 		}
 
-		pulsarConsumer, err := backend.NewPulsarMessageConsumer(cfg, pulsarClient)
+		pulsarReader, err := backend.NewPulsarMessageReader(cfg, pulsarClient)
 		if err != nil {
-			logger.L().Fatal("failed to create pulsar consumer", helpers.Error(err), helpers.String("config", fmt.Sprintf("%+v", cfg.Backend.PulsarConfig)))
+			logger.L().Fatal("failed to create pulsar reader", helpers.Error(err), helpers.String("config", fmt.Sprintf("%+v", cfg.Backend.PulsarConfig)))
 		}
 
-		adapter = backend.NewBackendAdapter(ctx, pulsarProducer, pulsarConsumer)
+		adapter = backend.NewBackendAdapter(ctx, pulsarProducer, pulsarReader)
 	} else {
 		// mock adapter
 		logger.L().Info("initializing mock adapter")

--- a/core/synchronizer.go
+++ b/core/synchronizer.go
@@ -145,6 +145,7 @@ func (s *Synchronizer) Start(ctx context.Context) error {
 	logger.L().Info("starting synchronization",
 		helpers.String("account", identifiers.Account),
 		helpers.String("cluster", identifiers.Cluster),
+		helpers.String("connId", identifiers.ConnectionId),
 		helpers.String("host", hostname))
 
 	if s.isClient {
@@ -167,9 +168,11 @@ func (s *Synchronizer) Start(ctx context.Context) error {
 func (s *Synchronizer) Stop(ctx context.Context) error {
 	hostname, _ := os.Hostname()
 	identifier := utils.ClientIdentifierFromContext(ctx)
+
 	logger.L().Info("stopping synchronization",
 		helpers.String("account", identifier.Account),
 		helpers.String("cluster", identifier.Cluster),
+		helpers.String("connId", identifier.ConnectionId),
 		helpers.String("host", hostname),
 	)
 	return s.adapter.Stop(ctx)

--- a/domain/identifiers.go
+++ b/domain/identifiers.go
@@ -19,10 +19,15 @@ func (c KindName) String() string {
 }
 
 type ClientIdentifier struct {
-	Account string
-	Cluster string
+	Account      string
+	Cluster      string
+	ConnectionId string
 }
 
 func (c ClientIdentifier) String() string {
 	return strings.Join([]string{c.Account, c.Cluster}, "/")
+}
+
+func (c ClientIdentifier) ConnectionString() string {
+	return strings.Join([]string{c.Account, c.Cluster, c.ConnectionId}, "/")
 }

--- a/domain/identifiers.go
+++ b/domain/identifiers.go
@@ -1,6 +1,9 @@
 package domain
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 type KindName struct {
 	Kind      *Kind
@@ -19,9 +22,10 @@ func (c KindName) String() string {
 }
 
 type ClientIdentifier struct {
-	Account      string
-	Cluster      string
-	ConnectionId string
+	Account        string
+	Cluster        string
+	ConnectionId   string
+	ConnectionTime time.Time
 }
 
 func (c ClientIdentifier) String() string {

--- a/messaging/interface.go
+++ b/messaging/interface.go
@@ -12,7 +12,7 @@ type MessageProducer interface {
 	ProduceMessage(ctx context.Context, id domain.ClientIdentifier, eventType string, payload []byte) error
 }
 
-type MessageConsumer interface {
-	// Start starts the message consumer and blocks until the context is done
+type MessageReader interface {
+	// Start starts the message reader and blocks until the context is done
 	Start(mainContext context.Context, adapter adapters.Adapter)
 }


### PR DESCRIPTION
## Overview

List of changes:
1. Whenever a client connects to the server, the server will generate a connection id and set the connection time. Since the adapter keeps the latest client attached to a specific (cluster, account) pair, before replacing it, it will check for an existing connection and will make sure the map is updated only for connections created with a greater timestamp.

This is to avoid a scenario with two connection attempts, where the map was already updated with the new client, but then a `Stop()` was invoked on the closed connection (causing the updated client to be removed from the map)

2. The synchronizer server will work with Reader instead of Consumer with a subscription for consuming Pulsar messages. A reader is a consumer without a cursor. This fixes an issue, where an instance of the server was terminated but the Pulsar subscription remained open (and not consumed).

As part of this change, when the server starts, it will start reading from the latest message of the topic. Unlike a consumer with a subscription, a reader does not acknowledge messages. At this point we are not implementing retries/DLQ.