### PR TITLE
Periodic reconciliation messages

### DIFF
--- a/adapters/backend/v1/client.go
+++ b/adapters/backend/v1/client.go
@@ -31,6 +31,7 @@ func (c *Client) Start(ctx context.Context) error {
 	if err := c.sendServerConnectedMessage(ctx); err != nil {
 		return fmt.Errorf("failed to produce server connected message: %w", err)
 	}
+
 	return nil
 }
 
@@ -327,7 +328,6 @@ func (c *Client) sendVerifyObjectMessage(ctx context.Context, id domain.KindName
 	return c.messageProducer.ProduceMessage(ctx, cId, messaging.MsgPropEventValueVerifyObjectMessage, data)
 }
 
-// TODO: should be called periodically for each client
 func (c *Client) SendReconciliationRequestMessage(ctx context.Context) error {
 	ctx = utils.ContextFromGeneric(ctx, domain.Generic{})
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,7 +64,7 @@ func main() {
 			logger.L().Fatal("failed to create pulsar reader", helpers.Error(err), helpers.String("config", fmt.Sprintf("%+v", cfg.Backend.PulsarConfig)))
 		}
 
-		adapter = backend.NewBackendAdapter(ctx, pulsarProducer)
+		adapter = backend.NewBackendAdapter(ctx, pulsarProducer, cfg.Backend.ReconciliationTask)
 		pulsarReader.Start(ctx, adapter)
 	} else {
 		// mock adapter

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ type Backend struct {
 	PulsarConfig         *pulsarconfig.PulsarConfig  `mapstructure:"pulsarConfig"`
 	Topic                pulsarconnector.TopicName   `mapstructure:"topic"`
 	Prometheus           *PrometheusConfig           `mapstructure:"prometheusConfig"`
+	ReconciliationTask   *ReconciliationTaskConfig   `mapstructure:"reconciliationTaskConfig"`
 }
 
 type InCluster struct {
@@ -53,6 +54,11 @@ type AuthenticationServerConfig struct {
 type PrometheusConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 	Port    int  `mapstructure:"port"`
+}
+
+type ReconciliationTaskConfig struct {
+	TaskIntervalSeconds           int `mapstructure:"taskIntervalSeconds"`
+	IntervalFromConnectionSeconds int `mapstructure:"intervalFromConnectionSeconds"`
 }
 
 // Kind returns group/version/resource as a string.

--- a/configuration/server/config.json
+++ b/configuration/server/config.json
@@ -2,6 +2,7 @@
   "backend": {
     "subscription": "synchronizer-server",
     "topic": "synchronizer",
+    "reconciliationIntervalMinutes": 1,
     "pulsarConfig": {
       "url": "pulsar://localhost:6650",
       "tenant": "armo",

--- a/configuration/server/config.json
+++ b/configuration/server/config.json
@@ -2,7 +2,6 @@
   "backend": {
     "subscription": "synchronizer-server",
     "topic": "synchronizer",
-    "reconciliationIntervalMinutes": 1,
     "pulsarConfig": {
       "url": "pulsar://localhost:6650",
       "tenant": "armo",

--- a/tests/synchronizer_integration_test.go
+++ b/tests/synchronizer_integration_test.go
@@ -530,7 +530,7 @@ func createAndStartSynchronizerServer(t *testing.T, pulsarUrl, pulsarAdminUrl st
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(cluster.ctx)
-	serverAdapter := backend.NewBackendAdapter(ctx, pulsarProducer)
+	serverAdapter := backend.NewBackendAdapter(ctx, pulsarProducer, nil)
 	pulsarReader.Start(ctx, serverAdapter)
 	synchronizerServer, err := core.NewSynchronizerServer(ctx, serverAdapter, serverConn)
 	require.NoError(t, err)


### PR DESCRIPTION
## Overview

This is a continuation of https://github.com/kubescape/synchronizer/pull/46

In this PR we create a go routine in the Backend adapter which runs every `TaskIntervalSeconds` for every connected client (which was connected for at least `IntervalFromConnectionSeconds`). It will send a ReconciliationRequestMessage to pulsar which will be processed later by the ingester.