### PR TITLE
fix shadow objects map

### DIFF
--- a/adapters/incluster/v1/client.go
+++ b/adapters/incluster/v1/client.go
@@ -130,7 +130,7 @@ func (c *Client) Start(ctx context.Context) error {
 			}
 			if c.Strategy == domain.PatchStrategy {
 				// remove from known resources
-				delete(c.ShadowObjects, id.Name)
+				delete(c.ShadowObjects, id.String())
 			}
 		case event.Type == watch.Modified:
 			logger.L().Debug("modified resource", helpers.String("id", id.String()))
@@ -225,9 +225,9 @@ func (c *Client) callPutOrPatch(ctx context.Context, id domain.KindName, baseObj
 	if c.Strategy == domain.PatchStrategy {
 		if len(baseObject) > 0 {
 			// update reference object
-			c.ShadowObjects[id.Name] = baseObject
+			c.ShadowObjects[id.String()] = baseObject
 		}
-		if oldObject, ok := c.ShadowObjects[id.Name]; ok {
+		if oldObject, ok := c.ShadowObjects[id.String()]; ok {
 			// calculate checksum
 			checksum, err := utils.CanonicalHash(newObject)
 			if err != nil {
@@ -249,7 +249,7 @@ func (c *Client) callPutOrPatch(ctx context.Context, id domain.KindName, baseObj
 			}
 		}
 		// add/update known resources
-		c.ShadowObjects[id.Name] = newObject
+		c.ShadowObjects[id.String()] = newObject
 	} else {
 		err := c.callbacks.PutObject(ctx, id, newObject)
 		if err != nil {
@@ -327,7 +327,7 @@ func (c *Client) patchObject(ctx context.Context, id domain.KindName, checksum s
 		return object, fmt.Errorf("checksum mismatch: %s != %s", newChecksum, checksum)
 	}
 	// update known resources
-	c.ShadowObjects[id.Name] = modified
+	c.ShadowObjects[id.String()] = modified
 	// save object
 	return object, c.PutObject(ctx, id, modified)
 }

--- a/adapters/mock.go
+++ b/adapters/mock.go
@@ -245,9 +245,9 @@ func (m *MockAdapter) TestCallPutOrPatch(ctx context.Context, id domain.KindName
 	if m.patchStrategy {
 		if len(baseObject) > 0 {
 			// update reference object
-			m.shadowObjects[id.Name] = baseObject
+			m.shadowObjects[id.String()] = baseObject
 		}
-		if oldObject, ok := m.shadowObjects[id.Name]; ok {
+		if oldObject, ok := m.shadowObjects[id.String()]; ok {
 			// calculate checksum
 			checksum, err := utils.CanonicalHash(newObject)
 			if err != nil {
@@ -269,7 +269,7 @@ func (m *MockAdapter) TestCallPutOrPatch(ctx context.Context, id domain.KindName
 			}
 		}
 		// add/update known resources
-		m.shadowObjects[id.Name] = newObject
+		m.shadowObjects[id.String()] = newObject
 	} else {
 		err := m.callbacks.PutObject(ctx, id, newObject)
 		if err != nil {

--- a/tests/synchronizer_integration_test.go
+++ b/tests/synchronizer_integration_test.go
@@ -921,10 +921,17 @@ func TestSynchronizer_TC06(t *testing.T) {
 	require.NoError(t, err)
 	// modify applicationprofile in k8s
 	k8sAppProfile, err := td.clusters[0].storageclient.ApplicationProfiles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+
+	id := domain.KindName{
+		Kind:      "spdx.softwarecomposition.kubescape.io/v1beta1/applicationprofiles",
+		Name:      name,
+		Namespace: namespace,
+	}
+
 	require.NoError(t, err)
 	k8sAppProfile.Spec.Containers[0].Name = "nginx2"
 	// alter shadow object in client before updating k8s, the patch won't include the image change
-	appClient.(*incluster.Client).ShadowObjects[name], err = json.Marshal(k8sAppProfile)
+	appClient.(*incluster.Client).ShadowObjects[id.String()], err = json.Marshal(k8sAppProfile)
 	require.NoError(t, err)
 	_, err = td.clusters[0].storageclient.ApplicationProfiles(namespace).Update(context.TODO(), k8sAppProfile, metav1.UpdateOptions{})
 	require.NoError(t, err)

--- a/tests/synchronizer_integration_test.go
+++ b/tests/synchronizer_integration_test.go
@@ -923,7 +923,11 @@ func TestSynchronizer_TC06(t *testing.T) {
 	k8sAppProfile, err := td.clusters[0].storageclient.ApplicationProfiles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 
 	id := domain.KindName{
-		Kind:      "spdx.softwarecomposition.kubescape.io/v1beta1/applicationprofiles",
+		Kind: &domain.Kind{
+			Group:    "spdx.softwarecomposition.kubescape.io",
+			Version:  "v1beta1",
+			Resource: "applicationprofiles",
+		},
 		Name:      name,
 		Namespace: namespace,
 	}


### PR DESCRIPTION
## Overview

In-cluster client's ShadowMap key was inconsistent and not unique (should have been domain.KindName.String() because this is the unique identifier of a resource). 
At some places we used the `Name` as a key, and as a result, having resources with the same name and kind in different namespaces will result in a synchronization issue (collision).