### PR TITLE
Periodic Keepalive task which outputs the list of connected clients

### DIFF
--- a/adapters/backend/v1/adapter.go
+++ b/adapters/backend/v1/adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -264,10 +265,12 @@ func (a *Adapter) startKeepalivePeriodicTask(mainCtx context.Context, cfg *confi
 				a.connMapMutex.Lock()
 				logger.L().Info("running keepalive task for connected clients", helpers.Int("clients", len(a.connectionMap)))
 
+				hostname, _ := os.Hostname()
 				msg := messaging.ConnectedClientsMessage{
-					Clients:   make([]messaging.ConnectedClient, len(a.connectionMap)),
-					Timestamp: time.Now(),
-					MsgId:     utils.NewMsgId(),
+					ServerName: hostname,
+					Clients:    make([]messaging.ConnectedClient, len(a.connectionMap)),
+					Timestamp:  time.Now(),
+					MsgId:      utils.NewMsgId(),
 				}
 				i := 0
 				for _, clientId := range a.connectionMap {

--- a/adapters/backend/v1/pulsar.go
+++ b/adapters/backend/v1/pulsar.go
@@ -339,13 +339,13 @@ func NewPulsarMessageProducer(cfg config.Config, pulsarClient pulsarconnector.Cl
 }
 
 func (p *PulsarMessageProducer) ProduceMessage(ctx context.Context, id domain.ClientIdentifier, eventType string, payload []byte) error {
-	producerMessage := newProducerMessage(SynchronizerServerProducerKey, id.Account, id.Cluster, eventType, payload)
+	producerMessage := NewProducerMessage(SynchronizerServerProducerKey, id.Account, id.Cluster, eventType, payload)
 	p.producer.SendAsync(ctx, producerMessage, logPulsarSyncAsyncErrors)
 	return nil
 }
 
 func (p *PulsarMessageProducer) ProduceMessageWithoutIdentifier(ctx context.Context, eventType string, payload []byte) error {
-	producerMessage := newProducerMessage(SynchronizerServerProducerKey, "", "", eventType, payload)
+	producerMessage := NewProducerMessage(SynchronizerServerProducerKey, "", "", eventType, payload)
 	p.producer.SendAsync(ctx, producerMessage, logPulsarSyncAsyncErrors)
 	return nil
 }
@@ -370,7 +370,7 @@ func logPulsarSyncAsyncErrors(msgID pulsar.MessageID, message *pulsar.ProducerMe
 	}
 }
 
-func newProducerMessage(producerMessageKey, account, cluster, eventType string, payload []byte) *pulsar.ProducerMessage {
+func NewProducerMessage(producerMessageKey, account, cluster, eventType string, payload []byte) *pulsar.ProducerMessage {
 	producerMessageProperties := map[string]string{
 		messaging.MsgPropTimestamp: time.Now().Format(time.RFC3339Nano),
 		messaging.MsgPropEvent:     eventType,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,7 +64,7 @@ func main() {
 			logger.L().Fatal("failed to create pulsar reader", helpers.Error(err), helpers.String("config", fmt.Sprintf("%+v", cfg.Backend.PulsarConfig)))
 		}
 
-		adapter = backend.NewBackendAdapter(ctx, pulsarProducer, cfg.Backend.ReconciliationTask)
+		adapter = backend.NewBackendAdapter(ctx, pulsarProducer, cfg.Backend)
 		pulsarReader.Start(ctx, adapter)
 	} else {
 		// mock adapter

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Backend struct {
 	ConsumerWorkers      int                         `mapstructure:"consumerWorkers"`
 	Prometheus           *PrometheusConfig           `mapstructure:"prometheusConfig"`
 	ReconciliationTask   *ReconciliationTaskConfig   `mapstructure:"reconciliationTaskConfig"`
+	KeepAliveTask        *KeepAliveTaskConfig        `mapstructure:"keepAliveTaskConfig"`
 }
 
 type InCluster struct {
@@ -61,6 +62,10 @@ type PrometheusConfig struct {
 type ReconciliationTaskConfig struct {
 	TaskIntervalSeconds           int `mapstructure:"taskIntervalSeconds"`
 	IntervalFromConnectionSeconds int `mapstructure:"intervalFromConnectionSeconds"`
+}
+
+type KeepAliveTaskConfig struct {
+	TaskIntervalSeconds int `mapstructure:"taskIntervalSeconds"`
 }
 
 // Kind returns group/version/resource as a string.

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.27.0
 	github.com/testcontainers/testcontainers-go/modules/k3s v0.27.0
 	go.uber.org/multierr v1.11.0
+	golang.org/x/mod v0.14.0
 	golang.org/x/net v0.19.0
 	istio.io/pkg v0.0.0-20231221211216-7635388a563e
 	k8s.io/api v0.29.0
@@ -150,7 +151,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
-	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect

--- a/messaging/interface.go
+++ b/messaging/interface.go
@@ -10,6 +10,7 @@ import (
 type MessageProducer interface {
 	// ProduceMessage produces a message to a messaging system
 	ProduceMessage(ctx context.Context, id domain.ClientIdentifier, eventType string, payload []byte) error
+	ProduceMessageWithoutIdentifier(ctx context.Context, eventType string, payload []byte) error
 }
 
 type MessageReader interface {

--- a/messaging/messages.go
+++ b/messaging/messages.go
@@ -128,10 +128,11 @@ type ReconciliationRequestObject struct {
 }
 
 type ConnectedClientsMessage struct {
-	Clients   []ConnectedClient `json:"clients"`
-	Timestamp time.Time         `json:"keepalive"`
-	Depth     int               `json:"depth"`
-	MsgId     string            `json:"msgId"`
+	ServerName string            `json:"serverName"`
+	Clients    []ConnectedClient `json:"clients"`
+	Timestamp  time.Time         `json:"keepalive"`
+	Depth      int               `json:"depth"`
+	MsgId      string            `json:"msgId"`
 }
 
 type ConnectedClient struct {

--- a/messaging/messages.go
+++ b/messaging/messages.go
@@ -1,5 +1,7 @@
 package messaging
 
+import "time"
+
 const (
 	MsgPropTimestamp = "timestamp"
 	// MsgPropCluster is the property name for the cluster name
@@ -15,6 +17,7 @@ const (
 	MsgPropEventValuePutObjectMessage             = "PutObject"
 	MsgPropEventValueServerConnectedMessage       = "ServerConnected"
 	MsgPropEventValueReconciliationRequestMessage = "ReconciliationRequest"
+	MsgPropEventValueConnectedClientsMessage      = "ConnectedClients"
 )
 
 type DeleteObjectMessage struct {
@@ -122,4 +125,20 @@ type ReconciliationRequestObject struct {
 	ResourceVersion int    `json:"resourceVersion"`
 	Name            string `json:"name"`
 	Namespace       string `json:"namespace"`
+}
+
+type ConnectedClientsMessage struct {
+	Clients   []ConnectedClient `json:"clients"`
+	Timestamp time.Time         `json:"keepalive"`
+	Depth     int               `json:"depth"`
+	MsgId     string            `json:"msgId"`
+}
+
+type ConnectedClient struct {
+	Cluster             string    `json:"cluster"`
+	Account             string    `json:"account"`
+	SynchronizerVersion string    `json:"synchronizerVersion"`
+	HelmVersion         string    `json:"helmVersion"`
+	ConnectionId        string    `json:"connectionId"`
+	ConnectionTime      time.Time `json:"connectionTime"`
 }

--- a/tests/synchronizer_integration_test.go
+++ b/tests/synchronizer_integration_test.go
@@ -535,7 +535,7 @@ func createAndStartSynchronizerServer(t *testing.T, pulsarUrl, pulsarAdminUrl st
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(cluster.ctx)
-	serverAdapter := backend.NewBackendAdapter(ctx, pulsarProducer, nil)
+	serverAdapter := backend.NewBackendAdapter(ctx, pulsarProducer, config.Backend{})
 	pulsarReader.Start(ctx, serverAdapter)
 	synchronizerServer, err := core.NewSynchronizerServer(ctx, serverAdapter, serverConn)
 	require.NoError(t, err)


### PR DESCRIPTION
## Overview

A new periodic task in the synchronizer server which outputs the list of connected clients to pulsar


```mermaid

sequenceDiagram
    participant SynchronizerIC
    SynchronizerIC->>+SynchronizerBE : Connection Established
        Note over SynchronizerIC,SynchronizerBE: cluster, account, app info
    participant SynchronizerBE
    participant Pulsar
    participant Ingester
    participant Postgres
    loop Every 24 hours
        SynchronizerBE->>+Pulsar : ConnectedClients
        Note over SynchronizerBE,Pulsar: List of connected clients <br /> + attach current timestamp
    end
    Pulsar->>+Ingester: Consume ConnectedClients message
    Ingester->>+Postgres: Upsert
```