### PR TITLE
support reconciliation message as batch, improve memory

### DIFF
--- a/adapters/backend/v1/pulsar.go
+++ b/adapters/backend/v1/pulsar.go
@@ -31,15 +31,14 @@ const (
 // * Pulsar Message Reader  *//
 // ******************************
 
-var reconciliationMessageMutex sync.Mutex
-
 type PulsarMessageReader struct {
-	name           string
-	reader         pulsar.Reader
-	done           chan bool
-	messageChannel chan pulsar.Message
-	wg             sync.WaitGroup
-	workers        int
+	name                       string
+	reader                     pulsar.Reader
+	done                       chan bool
+	messageChannel             chan pulsar.Message
+	wg                         sync.WaitGroup
+	workers                    int
+	reconciliationMessageMutex sync.Mutex
 }
 
 var _ messaging.MessageReader = (*PulsarMessageReader)(nil)
@@ -186,8 +185,8 @@ func (c *PulsarMessageReader) handleSingleSynchronizerMessage(ctx context.Contex
 		var data messaging.ReconciliationRequestMessage
 		// this is a mutex to prevent multiple goroutines from processing multiple reconciliation messages at the same time
 		// as they are can be large
-		reconciliationMessageMutex.Lock()
-		defer reconciliationMessageMutex.Unlock()
+		c.reconciliationMessageMutex.Lock()
+		defer c.reconciliationMessageMutex.Unlock()
 		if err := json.Unmarshal(msg.Payload(), &data); err != nil {
 			return fmt.Errorf("failed to unmarshal message: %w", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,7 @@ type ReconciliationTaskConfig struct {
 	CronSchedule                  string `mapstructure:"cronSchedule"` // when this is set, taskIntervalSeconds is ignored
 	TaskIntervalSeconds           int    `mapstructure:"taskIntervalSeconds"`
 	IntervalFromConnectionSeconds int    `mapstructure:"intervalFromConnectionSeconds"`
+	SendBatch                     bool   `mapstructure:"sendBatch"` // if true, a single message will be sent for all connected clients
 }
 
 type KeepAliveTaskConfig struct {

--- a/messaging/messages.go
+++ b/messaging/messages.go
@@ -23,14 +23,15 @@ const (
 	// MsgPropResourceVersion is the property name for the resource version of the resource
 	MsgPropResourceVersion = "resourceVersion"
 
-	MsgPropEventValueGetObjectMessage             = "GetObject"
-	MsgPropEventValuePatchObjectMessage           = "PatchObject"
-	MsgPropEventValueVerifyObjectMessage          = "VerifyObject"
-	MsgPropEventValueDeleteObjectMessage          = "DeleteObject"
-	MsgPropEventValuePutObjectMessage             = "PutObject"
-	MsgPropEventValueServerConnectedMessage       = "ServerConnected"
-	MsgPropEventValueReconciliationRequestMessage = "ReconciliationRequest"
-	MsgPropEventValueConnectedClientsMessage      = "ConnectedClients"
+	MsgPropEventValueGetObjectMessage                  = "GetObject"
+	MsgPropEventValuePatchObjectMessage                = "PatchObject"
+	MsgPropEventValueVerifyObjectMessage               = "VerifyObject"
+	MsgPropEventValueDeleteObjectMessage               = "DeleteObject"
+	MsgPropEventValuePutObjectMessage                  = "PutObject"
+	MsgPropEventValueServerConnectedMessage            = "ServerConnected"
+	MsgPropEventValueReconciliationRequestMessage      = "ReconciliationRequest"
+	MsgPropEventValueReconciliationRequestMessageBatch = "ReconciliationRequestBatch"
+	MsgPropEventValueConnectedClientsMessage           = "ConnectedClients"
 )
 
 type DeleteObjectMessage struct {
@@ -131,6 +132,12 @@ type ReconciliationRequestMessage struct {
 	MsgId           string                                   `json:"msgId"`
 	ServerInitiated bool                                     `json:"serverInitiated"`
 	KindToObjects   map[string][]ReconciliationRequestObject `json:"kindToObject"`
+}
+
+type ReconciliationRequestMessageBatch struct {
+	Depth    int                            `json:"depth"`
+	MsgId    string                         `json:"msgId"`
+	Requests []ReconciliationRequestMessage `json:"requests"`
 }
 
 type ReconciliationRequestObject struct {


### PR DESCRIPTION
## Overview

This PR introduces the following changes:
1. Allow one incoming reconciliation message processing (using mutex) to reduce memory consumption when unmarshaling big payloads.
2. Send a single reconciliation request for all connected clients