### PR TITLE
feat: propagate Azure ResourceGroup for synchronizer clients

### DIFF
--- a/adapters/backend/v1/adapter.go
+++ b/adapters/backend/v1/adapter.go
@@ -375,16 +375,18 @@ func (a *Adapter) startKeepalivePeriodicTask(mainCtx context.Context, cfg *confi
 				}
 				i := 0
 				for _, clientId := range a.connectionMap {
-					msg.Clients[i] = messaging.ConnectedClient{
-						Account:             clientId.Account,
-						Cluster:             clientId.Cluster,
-						SynchronizerVersion: clientId.SyncVersion,
-						HelmVersion:         clientId.HelmVersion,
-						ConnectionId:        clientId.ConnectionId,
-						ConnectionTime:      clientId.ConnectionTime,
-						GitVersion:          clientId.GitVersion,
-						CloudProvider:       clientId.CloudProvider,
-					}
+				msg.Clients[i] = messaging.ConnectedClient{
+					Account:             clientId.Account,
+					Cluster:             clientId.Cluster,
+					SynchronizerVersion: clientId.SyncVersion,
+					HelmVersion:         clientId.HelmVersion,
+					ConnectionId:        clientId.ConnectionId,
+					ConnectionTime:      clientId.ConnectionTime,
+					GitVersion:          clientId.GitVersion,
+					CloudProvider:       clientId.CloudProvider,
+					ClusterUID:          clientId.ClusterUID,
+					ResourceGroup:       clientId.ResourceGroup,
+				}
 					i += 1
 				}
 				a.connMapMutex.Unlock()

--- a/adapters/backend/v1/client.go
+++ b/adapters/backend/v1/client.go
@@ -116,6 +116,7 @@ func (c *Client) sendSingleConnectedClientsMessage(ctx context.Context) error {
 				GitVersion:          id.GitVersion,
 				CloudProvider:       id.CloudProvider,
 				ClusterUID:          id.ClusterUID,
+				ResourceGroup:       id.ResourceGroup,
 			}},
 		Timestamp: time.Now(),
 		MsgId:     utils.NewMsgId(),

--- a/adapters/incluster/v1/apiserver.go
+++ b/adapters/incluster/v1/apiserver.go
@@ -3,6 +3,7 @@ package incluster
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/kubescape/go-logger"
@@ -12,6 +13,11 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// azureResourceGroupMarker is the path segment that precedes the resource
+// group name inside an Azure-style Kubernetes node providerID, e.g.
+// azure:///subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Compute/...
+const azureResourceGroupMarker = "/resourceGroups/"
 
 func GetApiServerGitVersionAndCloudProvider(ctx context.Context, k8sApi *k8sinterface.KubernetesApi) (string, string) {
 	if k8sApi == nil {
@@ -64,6 +70,53 @@ func getCloudProvider(ctx context.Context, k8sApi *k8sinterface.KubernetesApi) (
 		return "", fmt.Errorf("no nodes found in the cluster")
 	}
 	return clouds.GetCloudProvider(nodeList), nil
+}
+
+// GetResourceGroup returns the Azure resource group hosting the cluster by
+// parsing the providerID of any node (all nodes of an AKS cluster share the
+// same resource group). Returns an empty string for non-Azure clusters or if
+// the information cannot be determined; callers should treat emptiness as
+// "unknown" rather than an error.
+func GetResourceGroup(ctx context.Context, k8sApi *k8sinterface.KubernetesApi) string {
+	if k8sApi == nil {
+		logger.L().Ctx(ctx).Warning("no kubernetes client for ResourceGroup")
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	nodeList, err := k8sApi.KubernetesClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		logger.L().Ctx(ctx).Warning("failed to list nodes for ResourceGroup", helpers.Error(err))
+		return ""
+	}
+	if len(nodeList.Items) == 0 {
+		logger.L().Ctx(ctx).Warning("no nodes found in the cluster for ResourceGroup")
+		return ""
+	}
+
+	rg := parseAzureResourceGroup(nodeList.Items[0].Spec.ProviderID)
+	if rg != "" {
+		logger.L().Info("successfully retrieved ResourceGroup", helpers.String("resourceGroup", rg))
+	}
+	return rg
+}
+
+// parseAzureResourceGroup extracts the resource group name from a Kubernetes
+// node providerID using the Azure format documented at
+// https://learn.microsoft.com/azure/aks/ and mirrored by the kubescape
+// node-agent (see kubescape/node-agent/pkg/cloudmetadata.parseAzureResourceGroup).
+func parseAzureResourceGroup(providerID string) string {
+	idx := strings.Index(strings.ToLower(providerID), strings.ToLower(azureResourceGroupMarker))
+	if idx == -1 {
+		return ""
+	}
+	rest := providerID[idx+len(azureResourceGroupMarker):]
+	end := strings.Index(rest, "/")
+	if end == -1 {
+		return rest
+	}
+	return rest[:end]
 }
 
 func getApiServerGitVersion(k8sApi *k8sinterface.KubernetesApi) (string, error) {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -102,6 +102,7 @@ func main() {
 
 	gitVersion, cloudProvider := incluster.GetApiServerGitVersionAndCloudProvider(ctx, k8sApi)
 	clusterUID := incluster.GetClusterUID(ctx, k8sApi)
+	resourceGroup := incluster.GetResourceGroup(ctx, k8sApi)
 
 	// authentication headers
 	version := os.Getenv("RELEASE")
@@ -115,6 +116,7 @@ func main() {
 			core.GitVersionHeader:    {gitVersion},
 			core.CloudProviderHeader: {cloudProvider},
 			core.ClusterUIDHeader:    {clusterUID},
+			core.ResourceGroupHeader: {resourceGroup},
 		}),
 		NetDial: utils.GetDialer(),
 	}

--- a/cmd/server/authentication/authentication.go
+++ b/cmd/server/authentication/authentication.go
@@ -40,6 +40,7 @@ func AuthenticationServerMiddleware(cfg *config.AuthenticationServerConfig, next
 		cloudProvider := r.Header.Get(core.CloudProviderHeader)
 		gitVersion := r.Header.Get(core.GitVersionHeader)
 		clusterUID := r.Header.Get(core.ClusterUIDHeader)
+		resourceGroup := r.Header.Get(core.ResourceGroupHeader)
 
 		if accessKey == "" || account == "" || cluster == "" {
 			logger.L().Error("missing headers on incoming connection",
@@ -130,6 +131,7 @@ func AuthenticationServerMiddleware(cfg *config.AuthenticationServerConfig, next
 			CloudProvider:  cloudProvider,
 			GitVersion:     gitVersion,
 			ClusterUID:     clusterUID,
+			ResourceGroup:  resourceGroup,
 		})
 		ctx = context.WithValue(ctx, domain.ContextKeyAccessKey, accessKey)
 

--- a/core/headers.go
+++ b/core/headers.go
@@ -10,4 +10,5 @@ const (
 	GitVersionHeader    = "X-GIT-VERSION"
 	CloudProviderHeader = "X-CLOUD-PROVIDER"
 	ClusterUIDHeader    = "X-CLUSTER-UID"
+	ResourceGroupHeader = "X-RESOURCE-GROUP"
 )

--- a/domain/identifiers.go
+++ b/domain/identifiers.go
@@ -73,6 +73,7 @@ type ClientIdentifier struct {
 	GitVersion     string
 	CloudProvider  string
 	ClusterUID     string
+	ResourceGroup  string
 }
 
 func (c ClientIdentifier) String() string {

--- a/messaging/messages.go
+++ b/messaging/messages.go
@@ -166,4 +166,5 @@ type ConnectedClient struct {
 	GitVersion          string    `json:"gitVersion"`
 	CloudProvider       string    `json:"cloudProvider"`
 	ClusterUID          string    `json:"clusterUID"`
+	ResourceGroup       string    `json:"resourceGroup,omitempty"`
 }


### PR DESCRIPTION
Discover Azure ResourceGroup from the node providerID and send it via X-RESOURCE-GROUP, then include it in ConnectedClients payloads (initial and keepalive) so downstream persistence can store it.

Also fixes keepalive payload to preserve ClusterUID.

Made-with: Cursor

## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Azure resource group information is now automatically detected and included in client identity and telemetry tracking for better resource organization visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->