### PR TITLE
cache authentication results in server middleware

### DIFF
--- a/cmd/server/authentication/authentication.go
+++ b/cmd/server/authentication/authentication.go
@@ -15,10 +15,47 @@ import (
 	"github.com/kubescape/synchronizer/domain"
 )
 
+const defaultCacheTTLSeconds = 600
+
 var (
 	client *http.Client
 	once   sync.Once // used to initialize authHttpClient
+
+	// authCache stores positive auth results (200 OK from the upstream auth
+	// server) keyed by accessKey+account. Values are the absolute expiry
+	// time. Failures are not cached and fall through to the existing error
+	// path so an outage at the auth URL does not lock customers out longer
+	// than it would today.
+	authCache    sync.Map
+	authCacheTTL time.Duration
 )
+
+func authCacheKey(accessKey, account string) string {
+	return accessKey + account
+}
+
+// authCacheLookup returns true if the key has a non-expired entry. Expired
+// entries are removed opportunistically.
+func authCacheLookup(key string, now time.Time) bool {
+	v, ok := authCache.Load(key)
+	if !ok {
+		return false
+	}
+	expiry, ok := v.(time.Time)
+	if !ok {
+		authCache.Delete(key)
+		return false
+	}
+	if now.After(expiry) {
+		authCache.Delete(key)
+		return false
+	}
+	return true
+}
+
+func authCacheStore(key string, expiry time.Time) {
+	authCache.Store(key, expiry)
+}
 
 func AuthenticationServerMiddleware(cfg *config.AuthenticationServerConfig, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -27,6 +64,13 @@ func AuthenticationServerMiddleware(cfg *config.AuthenticationServerConfig, next
 				logger.L().Warning("authentication server is not set; Incoming connections will not be authenticated")
 			} else {
 				client = &http.Client{}
+				ttlSeconds := cfg.CacheTTLSeconds
+				if ttlSeconds <= 0 {
+					ttlSeconds = defaultCacheTTLSeconds
+				}
+				authCacheTTL = time.Duration(ttlSeconds) * time.Second
+				logger.L().Info("authentication cache enabled",
+					helpers.Int("ttlSeconds", ttlSeconds))
 			}
 		})
 		connectionTime := time.Now()
@@ -57,57 +101,71 @@ func AuthenticationServerMiddleware(cfg *config.AuthenticationServerConfig, next
 
 		if client != nil {
 
-			u, err := url.Parse(cfg.Url)
-			if err != nil {
-				panic(err)
-			}
-
-			// copy headers to authentication request query params (configurable)
-			q := u.Query()
-			for header, queryParam := range cfg.HeaderToQueryParamMapping {
-				q.Set(queryParam, r.Header.Get(header))
-			}
-			u.RawQuery = q.Encode()
-
-			logger.L().Debug("creating authentication request",
-				helpers.String("connId", connectionId),
-				helpers.String("url", u.String()))
-
-			authenticationRequest, err := http.NewRequestWithContext(r.Context(), http.MethodGet, u.String(), nil)
-			if err != nil {
-				logger.L().Error("unable to create authentication request", helpers.Error(err))
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-
-			for origin, dest := range cfg.HeaderToHeaderMapping {
-				authenticationRequest.Header.Set(dest, r.Header.Get(origin))
-			}
-			logger.L().Debug("authenticating incoming connection",
-				helpers.Int("accessKey (length)", len(accessKey)),
-				helpers.String("account", account),
-				helpers.String("cluster", cluster),
-				helpers.String("connId", connectionId),
-				helpers.String("url", u.String()))
-
-			response, err := client.Do(authenticationRequest)
-			if err != nil {
-				logger.L().Error("authentication request failed", helpers.Error(err),
+			cacheKey := authCacheKey(accessKey, account)
+			if authCacheLookup(cacheKey, connectionTime) {
+				logger.L().Debug("authentication cache hit; skipping upstream call",
 					helpers.String("account", account),
 					helpers.String("cluster", cluster),
+					helpers.String("connId", connectionId))
+			} else {
+				u, err := url.Parse(cfg.Url)
+				if err != nil {
+					panic(err)
+				}
+
+				// copy headers to authentication request query params (configurable)
+				q := u.Query()
+				for header, queryParam := range cfg.HeaderToQueryParamMapping {
+					q.Set(queryParam, r.Header.Get(header))
+				}
+				u.RawQuery = q.Encode()
+
+				logger.L().Debug("creating authentication request",
 					helpers.String("connId", connectionId),
 					helpers.String("url", u.String()))
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			} else if response.StatusCode != http.StatusOK {
-				logger.L().Error("authentication server did not authorize the connection",
+
+				authenticationRequest, err := http.NewRequestWithContext(r.Context(), http.MethodGet, u.String(), nil)
+				if err != nil {
+					logger.L().Error("unable to create authentication request", helpers.Error(err))
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				for origin, dest := range cfg.HeaderToHeaderMapping {
+					authenticationRequest.Header.Set(dest, r.Header.Get(origin))
+				}
+				logger.L().Debug("authenticating incoming connection",
 					helpers.Int("accessKey (length)", len(accessKey)),
 					helpers.String("account", account),
 					helpers.String("cluster", cluster),
 					helpers.String("connId", connectionId),
-					helpers.Int("statusCode", response.StatusCode))
-				w.WriteHeader(http.StatusUnauthorized)
-				return
+					helpers.String("url", u.String()))
+
+				response, err := client.Do(authenticationRequest)
+				if err != nil {
+					logger.L().Error("authentication request failed", helpers.Error(err),
+						helpers.String("account", account),
+						helpers.String("cluster", cluster),
+						helpers.String("connId", connectionId),
+						helpers.String("url", u.String()))
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				} else if response.StatusCode != http.StatusOK {
+					logger.L().Error("authentication server did not authorize the connection",
+						helpers.Int("accessKey (length)", len(accessKey)),
+						helpers.String("account", account),
+						helpers.String("cluster", cluster),
+						helpers.String("connId", connectionId),
+						helpers.Int("statusCode", response.StatusCode))
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				// success: cache the positive result. Only positive results
+				// are cached so transient failures do not poison the cache.
+				if authCacheTTL > 0 {
+					authCacheStore(cacheKey, connectionTime.Add(authCacheTTL))
+				}
 			}
 		}
 

--- a/cmd/server/authentication/authentication_test.go
+++ b/cmd/server/authentication/authentication_test.go
@@ -1,0 +1,174 @@
+package authentication
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kubescape/synchronizer/config"
+	"github.com/kubescape/synchronizer/core"
+	"github.com/stretchr/testify/assert"
+)
+
+// resetMiddlewareState clears package-level state between tests so each test
+// case re-initializes via sync.Once.
+func resetMiddlewareState() {
+	once = sync.Once{}
+	client = nil
+	authCache = sync.Map{}
+	authCacheTTL = 0
+}
+
+func newRequestWithHeaders(accessKey, account, cluster string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set(core.AccessKeyHeader, accessKey)
+	r.Header.Set(core.AccountHeader, account)
+	r.Header.Set(core.ClusterNameHeader, cluster)
+	return r
+}
+
+// TestAuthenticationCacheHit verifies that a second connection from the same
+// (accessKey, account) within the TTL window does not trigger an upstream
+// auth call.
+func TestAuthenticationCacheHit(t *testing.T) {
+	resetMiddlewareState()
+
+	var upstreamCalls int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&upstreamCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.AuthenticationServerConfig{
+		Url:             upstream.URL,
+		CacheTTLSeconds: 60,
+	}
+
+	var nextCalls int32
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&nextCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := AuthenticationServerMiddleware(cfg, next)
+
+	for i := 0; i < 5; i++ {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, newRequestWithHeaders("ak-1", "acc-1", "cluster-1"))
+		assert.Equal(t, http.StatusOK, rec.Code, "iteration %d", i)
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&upstreamCalls),
+		"only the first request should hit the upstream auth server")
+	assert.Equal(t, int32(5), atomic.LoadInt32(&nextCalls),
+		"all requests should reach the next handler")
+}
+
+// TestAuthenticationFailureNotCached verifies that a non-200 response from the
+// upstream is not stored in the cache: a subsequent request with the same
+// credentials still calls the upstream.
+func TestAuthenticationFailureNotCached(t *testing.T) {
+	resetMiddlewareState()
+
+	var upstreamCalls int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&upstreamCalls, 1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.AuthenticationServerConfig{
+		Url:             upstream.URL,
+		CacheTTLSeconds: 60,
+	}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("next handler should not be called when auth fails")
+	})
+	handler := AuthenticationServerMiddleware(cfg, next)
+
+	for i := 0; i < 3; i++ {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, newRequestWithHeaders("ak-2", "acc-2", "cluster-2"))
+		assert.Equal(t, http.StatusUnauthorized, rec.Code, "iteration %d", i)
+	}
+
+	assert.Equal(t, int32(3), atomic.LoadInt32(&upstreamCalls),
+		"every failed auth must hit the upstream; the cache must not be poisoned")
+
+	// after a failure, a recovered upstream should still be reachable
+	// (entry was never stored, so no expiry to wait for).
+	cacheKey := authCacheKey("ak-2", "acc-2")
+	_, present := authCache.Load(cacheKey)
+	assert.False(t, present, "failed auth must not create a cache entry")
+}
+
+// TestAuthenticationCacheExpiry verifies that an expired entry forces a new
+// upstream call.
+func TestAuthenticationCacheExpiry(t *testing.T) {
+	resetMiddlewareState()
+
+	var upstreamCalls int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&upstreamCalls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.AuthenticationServerConfig{
+		Url:             upstream.URL,
+		CacheTTLSeconds: 60,
+	}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := AuthenticationServerMiddleware(cfg, next)
+
+	// first call populates the cache
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newRequestWithHeaders("ak-3", "acc-3", "cluster-3"))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&upstreamCalls))
+
+	// force the cached entry to be in the past
+	cacheKey := authCacheKey("ak-3", "acc-3")
+	authCache.Store(cacheKey, time.Now().Add(-time.Second))
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, newRequestWithHeaders("ak-3", "acc-3", "cluster-3"))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&upstreamCalls),
+		"expired entry should force a fresh upstream call")
+}
+
+// TestAuthenticationCacheDefaultTTL verifies the 600s default is applied when
+// CacheTTLSeconds is zero.
+func TestAuthenticationCacheDefaultTTL(t *testing.T) {
+	resetMiddlewareState()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.AuthenticationServerConfig{
+		Url: upstream.URL,
+		// CacheTTLSeconds intentionally zero to exercise the default
+	}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := AuthenticationServerMiddleware(cfg, next)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newRequestWithHeaders("ak-4", "acc-4", "cluster-4"))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, time.Duration(defaultCacheTTLSeconds)*time.Second, authCacheTTL,
+		"default TTL should be applied when config value is zero")
+}

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,12 @@ type AuthenticationServerConfig struct {
 	Url                       string            `mapstructure:"url"`
 	HeaderToQueryParamMapping map[string]string `mapstructure:"headerToQueryParamMapping"`
 	HeaderToHeaderMapping     map[string]string `mapstructure:"headerToHeaderMapping"`
+	// CacheTTLSeconds controls the in-process TTL for positive auth results
+	// (status 200 from the upstream auth server). Repeated connections from
+	// the same (accessKey, account) within the TTL window will skip the
+	// upstream auth call. Failures are never cached. When zero or unset, a
+	// default of 600 seconds (10 minutes) is applied.
+	CacheTTLSeconds int `mapstructure:"cacheTTLSeconds"`
 }
 
 type PrometheusConfig struct {


### PR DESCRIPTION
## Problem

`AuthenticationServerMiddleware` (`cmd/server/authentication/authentication.go`) fires an HTTP `GET` to the configured `cfg.Url` on **every** incoming agent WebSocket connection. There is currently **no caching at all**.

In production, `cfg.Url` is `http://ca-dashboard-be-egg.event-sourcing-be-prod.svc.cluster.local:7666/api/v1` and `ca-synchronizer-server` runs with `replicaCount: 15`. Every agent reconnect therefore turns into a request to `cadashboardbe` at `/api/v1?customerGUID=<account>`, accumulating 16k+/hr of avoidable load.

## Change

- Add an in-process TTL cache keyed by `accessKey + account` (the auth context).
  - **Cache lookup happens before the HTTP call.** On hit, the upstream call is skipped and a debug log line is emitted for observability.
  - **Only positive results (200 OK) are cached** with an absolute expiry time.
  - **Failures are never cached** (non-200 status, network errors). They fall through to the existing 401 path so an outage at the auth URL does not lock customers out longer than today, and failure semantics are unchanged.
- Cache state lives as package-level state (`sync.Map` + a `time.Duration`) initialized via the existing `sync.Once`, matching the surrounding pattern (`client *http.Client` + `once sync.Once`).
- The middleware function signature is unchanged.
- When `cfg.Url` is unset (auth-disabled mode) the cache is also disabled.

## Configuration

A new field on `AuthenticationServerConfig`:

```go
CacheTTLSeconds int `mapstructure:"cacheTTLSeconds"`
```

- Default: **600 seconds (10 minutes)** when zero/unset, so existing deployments benefit immediately without a chart change.
- The chart can override via `event-sourcing-chart` values to tune behavior; this PR does **not** require a chart change to be effective.

## Tests

`cmd/server/authentication/authentication_test.go` (new) exercises the middleware end-to-end with `httptest`:

- `TestAuthenticationCacheHit` — five identical requests result in only **one** upstream call.
- `TestAuthenticationFailureNotCached` — three failed requests each hit the upstream; no entry is created in the cache.
- `TestAuthenticationCacheExpiry` — an entry forced to be in the past triggers a fresh upstream call.
- `TestAuthenticationCacheDefaultTTL` — `CacheTTLSeconds = 0` resolves to the 600s default.

All pass (`go test ./cmd/server/authentication/...`).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./cmd/server/authentication/...` passes
- [x] `go test ./config/...` passes
- [ ] After merge, observe drop in `cadashboardbe` `GET /api/v1` traffic (expected ~order of magnitude given current 16k+/hr baseline and 10 min TTL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added authentication result caching that stores successful authentications to improve performance by reducing upstream calls. Only successful results are cached; failed attempts are not.
  * Added `CacheTTLSeconds` configuration option to control cache expiration time (defaults to 600 seconds when unset).

* **Tests**
  * Added comprehensive test suite validating authentication caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->