### PR TITLE
fix: drift sweep recovers from missed watch.Deleted events (SUB-7252)

### DIFF
--- a/adapters/incluster/v1/client.go
+++ b/adapters/incluster/v1/client.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -78,6 +79,12 @@ type Client struct {
 	ShadowObjects       map[string][]byte
 	Strategy            domain.Strategy
 	batchProcessingFunc map[domain.BatchType]BatchProcessingFunc
+	// driftSweepPeriod, when > 0, runs a periodic list of cluster state
+	// and emits synthetic DELETEs for objects the watch had marked alive
+	// but are no longer present (recovers from missed watch.Deleted).
+	driftSweepPeriod time.Duration
+	knownObjects     map[string]struct{} // key: namespace/name (or /name for cluster-scoped)
+	knownObjectsMu   sync.RWMutex
 }
 
 var errWatchClosed = errors.New("watch channel closed")
@@ -109,6 +116,8 @@ func NewClient(dynamicClient dynamic.Interface, storageClient spdxv1beta1.SpdxV1
 			domain.DefaultBatch:        defaultBatchProcessingFunc, // regular processing, when batch type is not set
 			domain.ReconciliationBatch: reconcileBatchProcessingFunc,
 		},
+		driftSweepPeriod: time.Duration(r.DriftSweepPeriodSeconds) * time.Second,
+		knownObjects:     map[string]struct{}{},
 	}
 }
 
@@ -136,6 +145,10 @@ func (c *Client) Start(ctx context.Context) error {
 	// begin watch
 	eventQueue := utils.NewCooldownQueue()
 	go c.watchRetry(ctx, watchOpts, eventQueue)
+	// drift sweep recovers from missed watch.Deleted events (SUB-7252)
+	if c.driftSweepPeriod > 0 {
+		go c.driftSweepLoop(ctx)
+	}
 	// process events
 	for event := range eventQueue.ResultChan {
 		// skip non-objects
@@ -158,6 +171,7 @@ func (c *Client) Start(ctx context.Context) error {
 		switch {
 		case event.Type == watch.Added:
 			logger.L().Debug("added resource", helpers.String("id", id.String()))
+			c.markKnown(d)
 			checksum, err := c.getChecksum(d)
 			if err != nil {
 				logger.L().Ctx(ctx).Error("cannot get checksum", helpers.Error(err), helpers.String("id", id.String()))
@@ -169,6 +183,7 @@ func (c *Client) Start(ctx context.Context) error {
 			}
 		case event.Type == watch.Deleted:
 			logger.L().Debug("deleted resource", helpers.String("id", id.String()))
+			c.markUnknown(d)
 			err := c.callbacks.DeleteObject(ctx, id)
 			if err != nil {
 				logger.L().Ctx(ctx).Error("cannot handle deleted resource", helpers.Error(err), helpers.String("id", id.String()))
@@ -179,6 +194,7 @@ func (c *Client) Start(ctx context.Context) error {
 			}
 		case event.Type == watch.Modified:
 			logger.L().Debug("modified resource", helpers.String("id", id.String()))
+			c.markKnown(d)
 			newObject, err := c.getObjectFromMeta(d)
 			if err != nil {
 				logger.L().Ctx(ctx).Error("cannot get object", helpers.Error(err), helpers.String("id", id.String()))
@@ -250,6 +266,117 @@ func (c *Client) watchRetry(ctx context.Context, watchOpts metav1.ListOptions, e
 			os.Exit(1)
 		}
 	}
+}
+
+// objectKey returns the namespace/name key used by the drift-sweep set.
+// Cluster-scoped resources have an empty namespace, yielding "/<name>".
+func objectKey(d metav1.Object) string {
+	return d.GetNamespace() + "/" + d.GetName()
+}
+
+func (c *Client) markKnown(d metav1.Object) {
+	c.knownObjectsMu.Lock()
+	c.knownObjects[objectKey(d)] = struct{}{}
+	c.knownObjectsMu.Unlock()
+}
+
+func (c *Client) markUnknown(d metav1.Object) {
+	c.knownObjectsMu.Lock()
+	delete(c.knownObjects, objectKey(d))
+	c.knownObjectsMu.Unlock()
+}
+
+// driftSweepLoop periodically lists the cluster state and emits synthetic
+// DELETE callbacks for resources the watch had marked alive but are no
+// longer present. This recovers from missed watch.Deleted events (e.g.
+// dropped during a watch channel restart). Tracked under SUB-7252.
+func (c *Client) driftSweepLoop(ctx context.Context) {
+	ticker := time.NewTicker(c.driftSweepPeriod)
+	defer ticker.Stop()
+	logger.L().Info("starting drift sweep",
+		helpers.String("resource", c.res.Resource),
+		helpers.String("period", c.driftSweepPeriod.String()))
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := c.driftSweep(ctx); err != nil {
+				logger.L().Ctx(ctx).Warning("drift sweep failed",
+					helpers.Error(err),
+					helpers.String("resource", c.res.Resource))
+			}
+		}
+	}
+}
+
+// driftSweep performs one drift-detection pass: list every cluster object
+// for this resource, then DELETE any object that was previously marked
+// known but is no longer present. New cluster items are silently added to
+// the known-set (seeding it; missed Adds are not back-filled to avoid
+// flapping the backend on first run).
+func (c *Client) driftSweep(ctx context.Context) error {
+	inCluster := mapset.NewSet[string]()
+	if err := pager.New(func(_ context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return c.chooseLister(opts)
+	}).EachListItem(context.Background(), metav1.ListOptions{}, func(obj runtime.Object) error {
+		item, ok := obj.(metav1.Object)
+		if !ok {
+			return nil
+		}
+		if c.isFiltered(item) {
+			return nil
+		}
+		inCluster.Add(objectKey(item))
+		return nil
+	}); err != nil {
+		return fmt.Errorf("list resources: %w", err)
+	}
+
+	// Collect orphans: in known-set but not in cluster.
+	c.knownObjectsMu.Lock()
+	orphans := make([]string, 0)
+	for k := range c.knownObjects {
+		if !inCluster.Contains(k) {
+			orphans = append(orphans, k)
+			delete(c.knownObjects, k)
+		}
+	}
+	// Seed known-set with anything new in the cluster so a future
+	// disappearance is detectable. We do not emit Verify here: the watch
+	// will catch up on its own and we want to avoid retransmit storms on
+	// process start.
+	for k := range inCluster.Iter() {
+		c.knownObjects[k] = struct{}{}
+	}
+	c.knownObjectsMu.Unlock()
+
+	if len(orphans) == 0 {
+		return nil
+	}
+
+	logger.L().Info("drift sweep detected missed deletes",
+		helpers.String("resource", c.res.Resource),
+		helpers.Int("count", len(orphans)))
+
+	for _, k := range orphans {
+		ns, name, _ := strings.Cut(k, "/")
+		id := domain.KindName{
+			Kind:      c.kind,
+			Name:      name,
+			Namespace: ns,
+		}
+		if err := c.callbacks.DeleteObject(ctx, id); err != nil {
+			logger.L().Ctx(ctx).Error("drift sweep: send delete failed",
+				helpers.Error(err),
+				helpers.String("id", id.String()))
+			continue
+		}
+		// PatchStrategy shadow entries are keyed by id.String() including a
+		// resource version we no longer have, so we leave them; they are
+		// overwritten on the next watch.Added or evicted on Client restart.
+	}
+	return nil
 }
 
 // isFiltered returns true if workload should be filtered out.

--- a/adapters/incluster/v1/drift_sweep_test.go
+++ b/adapters/incluster/v1/drift_sweep_test.go
@@ -1,0 +1,169 @@
+package incluster
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/kubescape/synchronizer/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// nodeUnstructured returns an unstructured node object the fake dynamic client
+// can list. The fake client uses the object's GVK for routing.
+func nodeUnstructured(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Node",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+		},
+	}
+}
+
+// TestClient_driftSweep_emitsDeleteForOrphans is the core regression test for
+// SUB-7252: when the watch has marked objects alive but they are no longer
+// present in the cluster, the drift sweep must emit DELETE for exactly those
+// missing objects and update the known set.
+func TestClient_driftSweep_emitsDeleteForOrphans(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Version: "v1", Kind: "Node"},
+		&unstructured.Unstructured{},
+	)
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Version: "v1", Kind: "NodeList"},
+		&unstructured.UnstructuredList{},
+	)
+
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
+	listGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "NodeList"}
+
+	// Cluster currently has node-a and node-c. node-b was deleted while the
+	// synchronizer's watch was disconnected, so the watch never saw the
+	// Deleted event.
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{gvr: listGVK.Kind},
+		nodeUnstructured("node-a"),
+		nodeUnstructured("node-c"),
+	)
+
+	var (
+		mu       sync.Mutex
+		deleted  []string
+	)
+	c := &Client{
+		dynamicClient: dynClient,
+		res:           gvr,
+		kind:          &domain.Kind{Group: "", Version: "v1", Resource: "nodes"},
+		Strategy:      domain.CopyStrategy,
+		knownObjects: map[string]struct{}{
+			"/node-a": {}, // alive in cluster
+			"/node-b": {}, // missed delete — should be reported
+			"/node-c": {}, // alive in cluster
+		},
+		callbacks: domain.Callbacks{
+			DeleteObject: func(_ context.Context, id domain.KindName) error {
+				mu.Lock()
+				defer mu.Unlock()
+				deleted = append(deleted, id.Name)
+				return nil
+			},
+		},
+	}
+
+	require.NoError(t, c.driftSweep(context.Background()))
+
+	mu.Lock()
+	sort.Strings(deleted)
+	mu.Unlock()
+	assert.Equal(t, []string{"node-b"}, deleted, "drift sweep should delete only the missed-delete orphan")
+
+	// Known set should now match cluster reality (node-b removed, node-a/node-c retained).
+	c.knownObjectsMu.RLock()
+	defer c.knownObjectsMu.RUnlock()
+	_, hasA := c.knownObjects["/node-a"]
+	_, hasB := c.knownObjects["/node-b"]
+	_, hasC := c.knownObjects["/node-c"]
+	assert.True(t, hasA)
+	assert.False(t, hasB, "orphan must be removed from known set after DELETE")
+	assert.True(t, hasC)
+}
+
+// TestClient_driftSweep_seedsNewClusterItems verifies that on first run the
+// sweep silently learns objects already in the cluster (so that a subsequent
+// disappearance is detectable) without emitting any callbacks for them.
+func TestClient_driftSweep_seedsNewClusterItems(t *testing.T) {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Version: "v1", Kind: "Node"},
+		&unstructured.Unstructured{},
+	)
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Version: "v1", Kind: "NodeList"},
+		&unstructured.UnstructuredList{},
+	)
+
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
+	listGVK := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "NodeList"}
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{gvr: listGVK.Kind},
+		nodeUnstructured("node-a"),
+		nodeUnstructured("node-b"),
+	)
+
+	c := &Client{
+		dynamicClient: dynClient,
+		res:           gvr,
+		kind:          &domain.Kind{Group: "", Version: "v1", Resource: "nodes"},
+		Strategy:      domain.CopyStrategy,
+		knownObjects:  map[string]struct{}{},
+		callbacks: domain.Callbacks{
+			DeleteObject: func(_ context.Context, id domain.KindName) error {
+				t.Fatalf("unexpected DeleteObject for %s on first sweep", id.Name)
+				return nil
+			},
+		},
+	}
+
+	require.NoError(t, c.driftSweep(context.Background()))
+
+	c.knownObjectsMu.RLock()
+	defer c.knownObjectsMu.RUnlock()
+	assert.Len(t, c.knownObjects, 2)
+	_, hasA := c.knownObjects["/node-a"]
+	_, hasB := c.knownObjects["/node-b"]
+	assert.True(t, hasA)
+	assert.True(t, hasB)
+}
+
+// TestClient_markKnown_markUnknown verifies the watch-loop hooks update the
+// drift-sweep set correctly under concurrent access.
+func TestClient_markKnown_markUnknown(t *testing.T) {
+	c := &Client{knownObjects: map[string]struct{}{}}
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"namespace": "ns", "name": "name"},
+	}}
+
+	c.markKnown(obj)
+	c.knownObjectsMu.RLock()
+	_, ok := c.knownObjects["ns/name"]
+	c.knownObjectsMu.RUnlock()
+	assert.True(t, ok, "markKnown should add ns/name to set")
+
+	c.markUnknown(obj)
+	c.knownObjectsMu.RLock()
+	_, ok = c.knownObjects["ns/name"]
+	c.knownObjectsMu.RUnlock()
+	assert.False(t, ok, "markUnknown should remove ns/name from set")
+}

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,13 @@ type Resource struct {
 	Version  string          `mapstructure:"version"`
 	Resource string          `mapstructure:"resource"`
 	Strategy domain.Strategy `mapstructure:"strategy"`
+	// DriftSweepPeriodSeconds enables a periodic drift sweep that lists the
+	// live cluster state for this resource and emits synthetic DELETE events
+	// for any object the watch had marked alive but is no longer present.
+	// This recovers from missed watch.Deleted events (e.g. dropped during a
+	// watch channel restart). 0 disables the sweep. Recommended for /v1/nodes
+	// and /v1/pods where stale records leak into account/billing views.
+	DriftSweepPeriodSeconds int `mapstructure:"driftSweepPeriodSeconds"`
 }
 
 type AuthenticationServerConfig struct {


### PR DESCRIPTION
## Summary
[SUB-7252](https://cyberarmor-io.atlassian.net/browse/SUB-7252) reports that customer Axual's `aks-np-dev` cluster shows 6 nodes in the UI when only 4 actually exist, and pods like `node-agent-c8tcf` / `node-agent-rkhtt` linger after deletion. The data is identical in Grafana, so the staleness is in the backend store, not the UI cache.

## Root cause
When a Kubernetes watch channel closes (network blip, API server timeout, scheduled re-list), any in-flight `watch.Deleted` events are lost. The watch resumes at the saved `ResourceVersion` but K8s does not replay history, so the synchronizer never propagates the delete and `node_statuses` / `pod_statuses` rows sit forever.

The existing `reconcileBatchProcessingFunc` already does the right diff (line 648 emits DELETE for orphans) — but only when the backend pushes a `ReconciliationBatch` snapshot, which is request-driven, not periodic. Stale records can therefore survive indefinitely.

## Fix
Per-resource drift sweep on the in-cluster `Client`:
- Maintain a `knownObjects` set keyed by `namespace/name`, populated by `watch.Added`/`watch.Modified` and pruned by `watch.Deleted`.
- On a configurable cadence (`Resource.DriftSweepPeriodSeconds`), list the live cluster and emit synthetic `DELETE` callbacks for any object that is in the known set but no longer present.
- Cluster items absent from the known set are silently learned (so a future disappearance is detectable without flapping the backend on first run).

The sweep is opt-in (`0` = disabled). Recommended cadence for `/v1/nodes` and `/v1/pods` in helm values is **300s** (5 min).

## Companion PRs
- [event-ingester-service#1790](https://github.com/armosec/event-ingester-service/pull/1790) — closes the downstream symptom (ghost `pod_statuses` rows once a DELETE message *does* arrive).

## Test plan
- [x] New unit tests in `adapters/incluster/v1/drift_sweep_test.go` cover orphan detection, first-run seeding, and concurrent mark-known/unknown.
- [x] `go build ./...` and `go vet ./adapters/incluster/v1/ ./config/` clean.
- [x] `go test ./adapters/incluster/v1/ -run "^TestClient_(filterAndMarshal|isFiltered|driftSweep|markKnown)|^Test_mergeMetadata$"` passes.
- [x] `go test ./config/` and `go test ./core/` pass.
- [ ] Helm: enable `driftSweepPeriodSeconds: 300` for `/v1/nodes` and `/v1/pods` in a separate values PR.
- [ ] Manual: in a staging cluster, kill the watch midway through a node delete; confirm the next sweep emits the DELETE within the configured period.

Refs: SUB-7252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional periodic drift detection to identify and clean up orphaned cluster objects missed by event watchers, improving cluster state reliability.

* **Chores**
  * Added per-resource configuration option to enable periodic drift sweeps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->