### PR TITLE
fix(httpendpoint): increase ReadTimeout for large network stream payloads

### DIFF
--- a/adapters/httpendpoint/v1/adapter.go
+++ b/adapters/httpendpoint/v1/adapter.go
@@ -39,7 +39,7 @@ func NewHTTPEndpointAdapter(cfg config.Config) *Adapter {
 		Addr:              fmt.Sprintf(":%s", cfg.HTTPEndpoint.ServerPort),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      10 * time.Second,
+		WriteTimeout:      35 * time.Second,
 		IdleTimeout:       120 * time.Second,
 		Handler:           httpMux,
 	}

--- a/adapters/httpendpoint/v1/adapter.go
+++ b/adapters/httpendpoint/v1/adapter.go
@@ -36,11 +36,12 @@ func NewHTTPEndpointAdapter(cfg config.Config) *Adapter {
 	})
 
 	server := &http.Server{
-		Addr:         fmt.Sprintf(":%s", cfg.HTTPEndpoint.ServerPort),
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		IdleTimeout:  120 * time.Second,
-		Handler:      httpMux,
+		Addr:              fmt.Sprintf(":%s", cfg.HTTPEndpoint.ServerPort),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		Handler:           httpMux,
 	}
 	a := &Adapter{
 		cfg:        cfg,


### PR DESCRIPTION
## Summary

- Split `ReadTimeout: 5s` into `ReadHeaderTimeout: 5s` + `ReadTimeout: 30s`
- The previous 5s `ReadTimeout` covered the full request (headers + body). Node-agent POSTs a full network stream snapshot every interval; on busy nodes the body read was racing with the timeout, causing the server to close the connection before sending a response. Node-agent then logged `context deadline exceeded (Client.Timeout exceeded while awaiting headers)`.
- `ReadHeaderTimeout` keeps protection against slow-header attacks; the higher `ReadTimeout` gives body reads enough headroom.

> **Deploy note**: deploy together with the matching `kubescape/node-agent` change that raises the client timeout to 30s.

## Test plan

- [ ] Verify no `context deadline exceeded` errors in node-agent logs after deploying both PRs together
- [ ] Confirm `/healthz` and normal synchronizer flows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)